### PR TITLE
Fix crash after enabling read research progress

### DIFF
--- a/scripts/research-automation-combinator.lua
+++ b/scripts/research-automation-combinator.lua
@@ -797,7 +797,8 @@ function ResearchAutomationCombinator:on_tick()
   -- We have a list of signals to output, so we need to set them in the combinator.  Most are already set, so we will merge our list in with the existing ones.
   -- Removing existing empty output will make our life way easier
   cb = cb or self:get_control_behavior()
-  parameters = parameters or cb.parameters
+  -- Using the existing parameters value here doesn't work for some reason
+  parameters = cb.parameters
   if (#parameters.outputs == 1 and not parameters.outputs[1].signal) then
     parameters.outputs = {}
   end


### PR DESCRIPTION
The local variable `parameters` was out of sync with `cb.parameters` after the changes in `self:add_output()`. I'd normally expect `parameters = cb.parameters` to assign a reference instead of a copy, but maybe the Lua API is returning a copy in the first place.

Closes: #1