### PR TITLE
feat: add research queue index selector

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -44,8 +44,8 @@ function on_research_change(event)
   end
 end
 
---- Handler for any change to the research queue (starting, finishing, cancelling, and moving research).
---- @param event EventData.on_research_finished|EventData.on_research_started|EventData.on_research_cancelled|EventData.on_research_moved
+--- Handler for any change to the research queue (starting, finishing, queueing, cancelling, and moving research).
+--- @param event EventData.on_research_finished|EventData.on_research_started|EventData.on_research_queued|EventData.on_research_cancelled|EventData.on_research_moved
 function on_research_queue_change(event)
   for _, rac in pairs(storage.research_combinators or {}) do
     if rac.entity and rac.entity.valid then
@@ -116,3 +116,4 @@ end
 script.on_event(defines.events.on_research_reversed, on_research_change)
 script.on_event(defines.events.on_research_started, on_research_queue_change)
 script.on_event(defines.events.on_research_moved, on_research_queue_change)
+script.on_event(defines.events.on_research_queued, on_research_queue_change)

--- a/locale/en/rac.cfg
+++ b/locale/en/rac.cfg
@@ -30,7 +30,9 @@ rac-research-get-science-packs=Get science packs for technology
 rac-research-get-science-packs-description=Get the science packs (or items) used to research the technologies in input signals.  When [font=default-bold]Output values derived from input[/font] is selected, output values will match each input signal.  When context-based output is selected, the output will be the required count per research increment.
 
 rac-research-current=Read current research
-rac-research-current-description=Outputs the technology that is currently being researched.
+rac-research-current-description=Outputs a technology from the research queue. Use the queue index to select which entry to output: 0 = currently being researched, 1 = next in queue, etc. If the index exceeds the queue length, nothing is output.
+rac-research-queue-index-label=Queue index
+rac-research-queue-index-label-description=The 0-based index of the technology in the research queue to output.\n[font=default-bold]0[/font] = currently being researched\n[font=default-bold]1[/font] = next in queue\nIf the index exceeds the queue length, nothing is output.
 rac-research-current-percent=Read research progress (%)
 rac-research-current-percent-description=Outputs the current research progress as a percentage value (0-100).
 rac-research-current-percent-label=Percent

--- a/scripts/gui.lua
+++ b/scripts/gui.lua
@@ -316,6 +316,32 @@ function create_gui(player, entity)
     tags = { rac=true },
     state = false,
   }
+  local hq = f.add{
+    type="flow",
+    name="research_current_queue_flow",
+    direction="horizontal",
+    style="player_input_horizontal_flow",
+  }
+  hq.style.horizontally_stretchable = true
+  hq.add{
+    type="label",
+    name="research_current_queue_label",
+    caption={"rac-research-queue-index-label"},
+    tooltip={"rac-research-queue-index-label-description"},
+  }
+  hq.add{
+    type="empty-widget",
+    style="rac_horizontal_pusher",
+  }
+  hq.add{
+    type="textfield",
+    name="research_current_queue_index",
+    style="short_number_textfield",
+    numeric = true,
+    allow_negative = false,
+    tooltip={"rac-research-queue-index-label-description"},
+    tags = { rac=true },
+  }
   f.add{
     type="line",
     style="inside_shallow_frame_with_padding_line",
@@ -518,6 +544,7 @@ function update_object_from_gui()
   -- Convert output side values to class values
   local output = storage.gui.content.h.research_output_mode.f
   rac.output_current_research = output.research_current_check.state
+  rac.output_current_research_queue_index = tonumber(output.research_current_queue_flow.research_current_queue_index.text) or 0
   rac.output_research_progress_percent = output.research_current_percent.state
   rac.output_research_progress_percent_signal = output.h.signal_percent.elem_value
   rac.output_research_progress_value = output.research_current_value.state
@@ -583,6 +610,8 @@ function update_gui_from_object()
   storage.gui.content.h.research_input_mode.f2.research_get_science_packs.state = rac.get_research_science_packs
 
   -- Set output states
+  storage.gui.content.h.research_output_mode.f.research_current_queue_flow.research_current_queue_label.enabled = rac.output_current_research
+  storage.gui.content.h.research_output_mode.f.research_current_queue_flow.research_current_queue_index.enabled = rac.output_current_research
   storage.gui.content.h.research_output_mode.f.h.signal_percent_label.enabled = rac.output_research_progress_percent
   storage.gui.content.h.research_output_mode.f.h.signal_percent.enabled = rac.output_research_progress_percent
   storage.gui.content.h.research_output_mode.f.h2.signal_current_label.enabled = rac.output_research_progress_value
@@ -594,6 +623,7 @@ function update_gui_from_object()
 
   -- Outputs
   storage.gui.content.h.research_output_mode.f.research_current_check.state = rac.output_current_research
+  storage.gui.content.h.research_output_mode.f.research_current_queue_flow.research_current_queue_index.text = tostring(rac.output_current_research_queue_index or 0)
   storage.gui.content.h.research_output_mode.f.research_current_percent.state = rac.output_research_progress_percent
   storage.gui.content.h.research_output_mode.f.h.signal_percent.elem_value = rac.output_research_progress_percent_signal
   storage.gui.content.h.research_output_mode.f.research_current_value.state = rac.output_research_progress_value

--- a/scripts/research-automation-combinator.lua
+++ b/scripts/research-automation-combinator.lua
@@ -231,6 +231,7 @@ end
 --- @field get_research_science_packs boolean Indicates that we should return the science packs required by the tech.
 --- @field io_mode IOMode Indicates whether output values should be derived from input signals or context-based (0=input_value, 1=context).
 --- @field output_current_research boolean Indicates we should output the current research.
+--- @field output_current_research_queue_index integer The 0-based index in the research queue to output (0 = currently researched, 1 = next in queue, etc.).
 --- @field output_research_progress_percent boolean Indicates we should output the research progress as a percentage.
 --- @field output_research_progress_percent_signal SignalID? The signal used for the research progress percentage.
 --- @field output_research_progress_value boolean Indicates we should output the research progress as a value.
@@ -254,6 +255,7 @@ ResearchAutomationCombinator = {
   get_research_science_packs = false,
   io_mode = IO_MODE.INPUT_VALUE,
   output_current_research = false,
+  output_current_research_queue_index = 0,
   output_research_progress_percent = false,
   output_research_progress_percent_signal = {
     name = "signal-percent",
@@ -461,6 +463,7 @@ function ResearchAutomationCombinator:update_combinator()
   --         10: available techs
   --         11: unresearched techs
   --     * Bit 11: Read current research
+  --     * Bits 12-19: Queue index (0 = currently researched, 1 = next in queue, etc.)
   --- @type uint32
   local mask = self.set_research_mode
 
@@ -488,6 +491,7 @@ function ResearchAutomationCombinator:update_combinator()
   if (self.output_current_research) then
     mask = bit32.bor(mask, 0x0400)
   end
+  mask = bit32.bor(mask, bit32.lshift(bit32.band(self.output_current_research_queue_index or 0, 0xFF), 11))
 
   cb.set_condition(5, {
     compare_type = "and",
@@ -570,6 +574,7 @@ function ResearchAutomationCombinator:configure_from_combinator()
   -- Get output conditions
   self.output_research_by_status = bit32.rshift(bit32.band(mask, 0x0300), 8)
   self.output_current_research = bit32.band(mask, 0x0400) ~= 0
+  self.output_current_research_queue_index = bit32.band(bit32.rshift(mask, 11), 0xFF)
 
   -- Read research (value)
   local read_research_value_cond = parameters.conditions[6]
@@ -1190,7 +1195,9 @@ end
 function ResearchAutomationCombinator:on_research_queue_change(event)
   local clear_research = false
   if self.output_current_research then
-    local tech = self.entity.force.current_research
+    local queue = self.entity.force.research_queue
+    local queue_index = self.output_current_research_queue_index or 0
+    local tech = queue and queue[queue_index + 1]
     if tech then
       local signal_name = "rac-technology-" .. tech.name
 


### PR DESCRIPTION
Adds an index selector to the read research progress toggle.

<img width="570" height="591" alt="grafik" src="https://github.com/user-attachments/assets/9fdabb70-ad93-4813-92aa-db1cecc45770" />

<img width="370" height="107" alt="grafik" src="https://github.com/user-attachments/assets/28993fc4-250d-4d23-969d-dc8d5debc20f" />

If you prefer 1-based indexes, we can use that as well.
And/Or replace the checkbox entirely and treat empty/-1/0 as implicitly disabled.

Research Queue:

<img width="539" height="114" alt="grafik" src="https://github.com/user-attachments/assets/d9f4a2a2-e3bc-4dcb-b824-7499ea3e4036" />

| Index | Output |
| --- | --- |
| 0 | <img width="39" height="37" alt="grafik" src="https://github.com/user-attachments/assets/4f1a22a1-57c7-4d3f-b1dc-98d33b0ee593" /> |
| 1 | <img width="39" height="36" alt="grafik" src="https://github.com/user-attachments/assets/10fe6f57-462b-465e-bdd3-987f88ad84b3" /> |
| 2 | <img width="43" height="41" alt="grafik" src="https://github.com/user-attachments/assets/14b4c58d-a099-4d54-a9ed-a55686108b54" /> |
| 3 | None |

Currently, this reserves 8bit to store that information, maybe we need less, but I couldn't find the scripted research queue limit.
Maybe 3 bits are sufficient 0-7 (0-6+disabled).

I can also provide the German translations (here or in #6) depending on which one you merge first.

